### PR TITLE
Update _variables.scss

### DIFF
--- a/superhero/_variables.scss
+++ b/superhero/_variables.scss
@@ -129,7 +129,7 @@ $table-condensed-cell-padding:  3px;
 //** Default background color used for all tables.
 $table-bg:                      transparent;
 //** Background color used for `.table-striped`.
-$table-bg-accent:               $well-bg;
+$table-bg-accent:               lighten($body-bg, 5%);
 //** Background color used for `.table-hover`.
 $table-bg-hover:                darken($well-bg, 3%);
 $table-bg-active:               $table-bg-hover;


### PR DESCRIPTION
The table background is white on .table-striped > tbody > tr:nth-of-type(odd). As the text color is light-gray the offset is far to great making this proposed change readable and prettier.